### PR TITLE
[ZS-861] update Zap Templates documentation 

### DIFF
--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -21,7 +21,7 @@ They’re also a great way to promote your app, as your Zap Templates are featur
 
 Zap Templates can also be featured inside your site and content to help your users start using Zapier integrations. The more Zap Templates you create and the more users they have, the more likely they are to be featured. This helps your Zapier integration gain popularity and rise the ranks of the [Zapier Partner Program](https://zapier.com/platform/partner-program).
 
-You can create Zap Templates for any public Zapier integration, or for any integration that has applied for publishing. Once you apply for publishing your integration, you will need to [build at least 10 Zap Templates](https://zapier.com/developer/zap-templates/) to help people start using your integration.
+You can create Zap Templates for any public Zapier integration, or for any integration that has applied for publishing. Once you apply for publishing your integration, you will need to [build at least 10 Zap Templates](https://zapier.com/zap-templates/) to help people start using your integration.
 
 > Expected time to create a Zap Template: <10 minutes.
 
@@ -150,7 +150,7 @@ And _Customize your shared Zap page_ in the modal.
 
 ![Zap Template shared Zap page](https://cdn.zappy.app/84df95e80f4689c645da674f226e7ef1.png)
 
-This Zap page is where you can customize the title and description for your Zap Template.
+This shared Zap page is where you can customize the title and description for your Zap Template.
 
 Zap Templates need to showcase a use case and describe it effectively. They provide inspiration for how to automate popular apps and workflows. Your Zap Template's title and description help sell that idea to users.
 
@@ -187,7 +187,7 @@ Follow these rules in your Zap Template Titles:
   - **Wrong:** `Slack will notify you when a new Google Drive file is saved`
 - **Always mention _new_ before trigger apps**. Zaps only run when new items are created in apps, and cannot take action for existing items. Emphasize that by including `new` in your title before the action app name.
 - **Make app items plural**. Zaps run on every new item in your trigger app, and will always create the related item in your action app(s). Always make the trigger and action items plural to emphasize that, such as `Google Sheets rows` or `Mailchimp subscribers`.
-- **Respect app name styles**. Make sure to use the same capitalization and spelling that the apps in your Zap use in their branding; double-check the app’s site or [Zapier’s integration list](https://zapier.com/help/service-documentation/).
+- **Respect app name styles**. Make sure to use the same capitalization and spelling that the apps in your Zap use in their branding; double-check the app’s site or [Zapier’s integration list](https://zapier.com/apps).
 - **Never use `sync` or `automatic` in titles**. All Zaps run automatically, only work on new data, and can’t sync data multiple ways. Avoid these terms in titles; sync is misleading, and automatic is redundant.
 - **Don’t use personal pronouns**. Never use `you`, `we`, or `I` in Zap Template titles unless the trigger or action items specifically include those words.
 
@@ -209,7 +209,7 @@ Keep these guidelines in mind:
 - **1 paragraph, 2-4 sentences** is enough for most Zap Template descriptions.
 - **Don’t use Zapier-specific terminology** including Zap, Zap Template, trigger, action, or terms that Zapier doesn’t support, such as sync. Instead, use generic words, such as `integration` or `automation`, that are universally understood.
 - **Use same terms as the integrations themselves**. If an app calls the results of a form an “entry” don’t call it a “submission,” or if an email app uses "tags," don’t refer to "folders."
-- **Include tips at the end**. If your Zap Template requires extra setup for filters or other steps, or if it doesn't cover all use cases users may expect, include a sentence at the end to clarify. Start the tip with `Note:`, and format the entire note in italics with [Markdown](https://zapier.com/blog/beginner-ultimate-guide-markdown/) formatting. For example: `*Note: Add the tag you want to the Zap's [Filter](https://zapier.com/learn/getting-started-guide/filters/) step.*`
+- **Include tips at the end**. If your Zap Template requires extra setup for filters or other steps, or if it doesn't cover all use cases users may expect, include a sentence at the end to clarify.
 
 > **Note**: Always write unique descriptions for each Zap Template—we will reject Zap Templates that use the same descriptions but only replace app names.
 
@@ -237,7 +237,7 @@ If your templates adhere to our style and construction guidelines, they will be 
 
 [Learn more about embedding tools like our JavaScript Widgets and Partner API here.](https://platform.zapier.com/partner_api/embedding)
 
-Then go ahead and make some more Zap Templates! Every Zapier integration must have at least 10 Zap Templates, and the more you make, the easier it will be to start using your Zapier integration. Open the [Zap Template Creator](https://zapier.com/developer/zap-templates/create) again and create any more Zap Templates you want.
+Then go ahead and make some more Zap Templates! Every Zapier integration must have at least 10 Zap Templates, and the more you make, the easier it will be to start using your Zapier integration. Open the [Zap editor](https://zapier.com/app/editor/) again and create any more Zap Templates you want.
 
 <a id="rejected-zap-templates"></a>
 #### Rejected Zap Templates
@@ -252,7 +252,7 @@ The most typical issues are titles and descriptions that are simply copies with 
 
 - _Needs a unique title/description:_ Your template was submitted with non-unique titles. Please reference [title](https://platform.zapier.com/partners/zap-templates#how-to-write-a-zap-template-title) and [description](https://platform.zapier.com/partners/zap-templates#how-to-write-a-zap-template-description) style guidelines and resubmit.
 - _Has content or style guide issues:_ There are other specific issues with your template - please review additional provided detail and general guidelines.
-- _Usecase is too specific:_ Templates are meant to be broad, starter usecases. Most commonly they have two steps, possibly three if a partner's integration value comes primarily from search actions. Templates with too many steps become too specific to be useful - we recommend building tutorials and referencing Shared Zaps for these.
+- _Use case is too specific:_ Templates are meant to be broad, starter usecases. Most commonly they have two steps, possibly three if a partner's integration value comes primarily from search actions. Templates with too many steps become too specific to be useful - we recommend building tutorials and referencing Shared Zaps for these.
 - _Mappings are incorrect or incomplete:_ Fields that were available from your trigger or preceding actions were not mapped, or not mapped accurately. Refer to [Action step guidelines.](https://platform.zapier.com/partners/zap-templates#2-add-an-action-step)
 - _Template already exists:_ Template duplicates another public template, or you submitted duplicates. Please consult the [Zapier App Directory](https://zapier.com/apps) to explore our public templates.
 - _Content should be in English:_ We only support Zap Templates in English.
@@ -279,7 +279,7 @@ Find your app’s App Directory page at `zapier.com/apps/YourApp/integrations`, 
 
 Want to find ways to connect two specific apps? Click one of the top apps on any App Directory page to see our two-app pages, such as the one above for Slack and Trello. It shows the most popular use cases for those two apps together.
 
-Find your app’s two-app pages at `zapier.com/apps/YourApp/integrations/OtherApp`, substituting `YourApp` with your app’s name and `OtherApp` with the other app connected to your app.
+Find your app’s two-app pages at `zapier.com/apps/YourApp/integrations/OtherApp`, substituting `YourApp` with your app’s name and `OtherApp` with the other app connected to your app. For example, [zapier.com/apps/trello/integrations/google-drive](https://zapier.com/apps/trello/integrations/google-drive).
 
 Zapier also shows these top use cases to logged in users, promoting your app’s top Zap Templates to people who have connected Zapier to your app.
 
@@ -291,7 +291,7 @@ You can also promote Zap Templates on your site with Zap embeds. The easiest way
 
 > **Tip**: Learn more about Zap Templates’ benefits in our [Zap Template presentation](https://docs.google.com/presentation/d/e/2PACX-1vQNBCEb0UsK75jnbsn9-1Ki5AnHJyxM8VfAiMHzOnXon2_HzEINt3D5l7a-_HoMDsIzBRjvN2FcWqXJ/pub?start=false&loop=false&delayms=15000).
 
-Want to embed specific individual Zap Templates instead? Copy the Zap ID number from your [Zap Templates Dashboard](https://zapier.com/developer/zap-templates/) by clicking the gear icon beside a Zap and selecting the _Copy ID_ option. Then, include it in place of `1234` in the text below:
+Want to embed specific individual Zap Templates instead? Copy the Zap ID number from your [Zap Templates Dashboard](https://zapier.com/zap-templates/) by clicking the gear icon beside a Zap and selecting the _Copy ID_ option. Then, include it in place of `1234` in the text below:
 
 `<script type="text/javascript" src="https://zapier.com/apps/embed/widget.js?guided_zaps=1234"></script>`
 
@@ -306,7 +306,7 @@ You can additionally use extra options to customize your Zap Template look and f
 
 ![Unbounce Embedded Zaps](https://cdn.zapier.com/storage/photos/ab298d02d423fb9a122b0a75ca7f7512.png)
 
-Want to build Zap Templates into your app? [Zapier’s Partner API](https://zapier.com/developer/documentation/v2/partner-api/) lets you do just that. It can embed a full App Directory into your app to showcase every app that works with your app’s Zapier integration, along with Zap Templates and any active Zaps your users have enabled.
+Want to build Zap Templates into your app? [Zapier’s Partner API](https://platform.zapier.com/partner_api/introduction) lets you do just that. It can embed a full App Directory into your app to showcase every app that works with your app’s Zapier integration, along with Zap Templates and any active Zaps your users have enabled.
 
 Zapier's embeds maintain Zapier’s design for the most part. With the Partner API, however, you can customize the entire look and feel of Zapier in your app. It’s the perfect way to make your Zapier integrations be first-class features in your app.
 
@@ -332,13 +332,13 @@ Here are some example embedded Zapier experiences with our Partner API, and you 
 
 ![Zap Template List](https://cdn.zapier.com/storage/photos/fd0cf812b5abc1f8ca5f0cec8029b428.png)
 
-One Zap Template isn’t enough—you’ll want to make Zap Templates for each of your app’s most popular use cases. Over time, you’ll likely make dozens of Zap Templates. You can manage them—in draft, review, or publicly available—from your [Zap Templates](https://zapier.com/developer/zap-templates/) dashboard alongside Zapier’s developer platform tools.
+One Zap Template isn’t enough—you’ll want to make Zap Templates for each of your app’s most popular use cases. Over time, you’ll likely make dozens of Zap Templates. You can manage them—in draft, review, or publicly available—from your [Zap Templates](https://zapier.com/zap-templates/) dashboard alongside Zapier’s developer platform tools.
 
 Filter through your Zap Templates by status on the left sidebar, click a Zap Template to edit it, or select the gear icon on the right of a Zap Template to copy its public link, test it, or delete it.
 
 If you have any Zap Templates in your _Rejected_ list, edit them to fix the issues then re-submit them. You cannot edit public Zap Templates, but if you notice something that you need to change in your existing Zap Templates, please email [partners@zapier.com](mailto:partners@zapier.com) with the link to the Zap Template, and we can set the Zap as _Draft_ again so you can edit and re-submit it with any changes.
 
-Then start again. Whenever you think of something that’s the _perfect_ use case for your Zapier integration, turn it into a Zap Template with the [Zap Template Creator](https://zapier.com/developer/zap-templates/create). As soon as it’s approved, it’ll show up everywhere your Zapier integration is promoted, spreading your use case to the people who will benefit from it most.
+Then start again. Whenever you think of something that’s the _perfect_ use case for your Zapier integration, turn it into a Zap Template with the [Zap editor](https://zapier.com/app/editor). As soon as it’s approved, it’ll show up everywhere your Zapier integration is promoted, spreading your use case to the people who will benefit from it most.
 
 ## Troubleshoot Zap Template Embeds
 

--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -269,15 +269,15 @@ It’s not enough to turn your ideal workflows into Zap Templates. You need to g
 
 ### Zapier App Directory
 
-![Zapier App Directory Page](https://cdn.zapier.com/storage/photos/b625939587cb8a8c7242f375c714d6aa.png)
+![Zapier App Directory Page](https://cdn.zappy.app/2019079afe2bcc82f2257a22eb4afd77.png)
 
-The easiest way to find Zap Templates is in Zapier’s [App Directory](https://zapier.com/apps/) where we have individual pages for each of the thousands that integrate with Zapier. Want to find Gmail integrations? Go to [zapier.com/apps/gmail/integrations](https://zapier.com/apps/gmail/integrations/) to see the top apps connected with Gmail on Zapier, followed by a list of popular Gmail Zap Templates and Zapier content about Gmail use cases.
+The easiest way to find Zap Templates is in Zapier’s [App Directory](https://zapier.com/apps/) where we have individual pages for each of the thousands that integrate with Zapier. Want to find Trello integrations? Go to [zapier.com/apps/trello/integrations](https://zapier.com/apps/trello/integrations/) to see the top apps connected with Trello on Zapier, followed by a list of popular Trello Zap Templates and Zapier content about Trello use cases.
 
 Find your app’s App Directory page at `zapier.com/apps/YourApp/integrations`, replacing `YourApp` with your app’s name.
 
-![Zapier App Directory two-app page](https://cdn.zapier.com/storage/photos/ca6556adda39eeb6f8477a873122d444.png)
+![Zapier App Directory two-app page](https://cdn.zappy.app/6ab8c80fdf2664eade6903ee74b66c56.png)
 
-Want to find ways to connect two specific apps? Click one of the top apps on any App Directory page to see our two-app pages, such as the one above for Trello and Gmail. It shows the most popular use cases for those two apps together.
+Want to find ways to connect two specific apps? Click one of the top apps on any App Directory page to see our two-app pages, such as the one above for Slack and Trello. It shows the most popular use cases for those two apps together.
 
 Find your app’s two-app pages at `zapier.com/apps/YourApp/integrations/OtherApp`, substituting `YourApp` with your app’s name and `OtherApp` with the other app connected to your app.
 
@@ -948,17 +948,17 @@ Each parameter is in a flattened dictionary/object syntax. For example an object
 
 Prefill Trello's board ID (field: `board`) in the second step of the Zap template:
 
-`https://zapier.com/app/editor/template/2405?steps__1__params__board=12345`
+`https://zapier.com/webintent/create-zap?template=2405&steps__1__params__board=12345`
 
 Here's what it would look like in the editor:
 
-![](https://cdn.zapier.com/storage/photos/1f3544e43787d1d2e0b528b08b909dcb.png)
+![](https://cdn.zappy.app/e3221301de448fde1b5017c9cdbe59d3.png)
 
 If you'd like to provide a label for the value (e.g. a Board's name) you can do so by passing an additional parameter:
 
 `https://zapier.com/webintent/create-zap?template=2405&steps__1__params__board=12345&steps__1__meta__parammap__board=My+Board`
 
-![](https://cdn.zapier.com/storage/photos/86b71a90bc69e5b13024c08f1da4b812.png)
+![](https://cdn.zappy.app/697fe1806f4c8cbf8bbcfa1ad0360626.png)
 
 #### The App Object
 

--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -17,27 +17,30 @@ They’re also a great way to promote your app, as your Zap Templates are featur
 
 - Zapier’s App Directory
 - Zapier’s onboarding experience
-- In many of Zapier's 1,300+ integration partners' apps and sites
+- In many of Zapier's thousands of integration partners' apps and sites
 
 Zap Templates can also be featured inside your site and content to help your users start using Zapier integrations. The more Zap Templates you create and the more users they have, the more likely they are to be featured. This helps your Zapier integration gain popularity and rise the ranks of the [Zapier Partner Program](https://zapier.com/platform/partner-program).
 
 You can create Zap Templates for any public Zapier integration, or for any integration that has applied for publishing. Once you apply for publishing your integration, you will need to build at least 10 Zap Templates in the [Zap Template Creator](https://zapier.com/developer/zap-templates/create) to help people start using your integration.
 
-> Expected time to create a Zap Template: 10 minutes.
+> Expected time to create a Zap Template: <10 minutes.
 
 ![Example Zap Template](https://cdn.zapier.com/storage/photos/c89bedd08435ca8e9dc42b348eca732c.gif)
 _An example Zap Template that automatically saves Gmail attachments to Google Drive—a handy way to speed up email file management._
+
+## How to Choose Zap Templates To Build
+
+You know your users best. Zap Templates should be built first and foremost to encourage people to adopt the usecases _you_ know are most valuable to your users. We recommend sourcing from your support teams, customer surveys, and internal usage of your product to determine all the various apps and workflows your users rely on every day - templatize and promote those!
+
+These should be broad usecases with a starter user in mind - they are often simple, with 2 and rarely 3 steps. Zap Templates should also illustrate the widest possible range of pairings. Focus primarily on templatizing usecases with the apps you hear about the most, but we also recommend exploring our [App Directory](https://zapier.com/apps) by category and making templates for other apps in the same categories as your more popular pairings.
+
+Please review the entire style guide below before submitting templates for review, and take particular note of our [Rejected Zap Templates](https://platform.zapier.com/partners/zap-templates#rejected-zap-templates) section. Templates that do not comply with our style guide will be rejected - preparing in advance will save you time with rounds of iteration if changes are required.
 
 ## How to Build a Zap Template
 
 Zap Templates take a few steps to build, similar to any other Zap. You first select the app and trigger you want to start the Zap, then add an action app and map the fields from the trigger app to the action—and optionally add additional steps. Then, add a title and description to help people quickly understand when to use your Zap.
 
-For help as you build, you can follow this video or the written instructions below:
-
-<div class="wistia_responsive_padding" style="padding:44.17% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><iframe src="https://fast.wistia.net/embed/iframe/0y50h71p98?seo=false&videoFoam=true" title="Zap template creator video howto" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe></div></div>
-<script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
-<br>
-<br>
+For help as you build, follow the instructions below:>
 
 ### 1. Add a Trigger Step
 
@@ -216,9 +219,39 @@ Finally, when your Zap Template is ready for public release, select the `For rev
 
 > **Note**: Zapier will only approve Zap Templates that include either public integrations or integrations that have applied for public release.
 
-We'll then contact you, typically within a couple of weeks, after reviewing your Zap Template(s). If your Zap Templates pass the tests, we will mark them as public to automatically have them show up on your app's App Directory page, inside select partners' apps and sites, and in Zapier's onboarding experience.
+Zap Templates are processed in order of arrival - please account for up to two weeks. The day after your Zap templates are processed, you will receive an automatic email with a digest detailing the status of each template you submitted.
 
-Then make some more Zap Templates. Every Zapier integration must have at least 10 Zap Templates, and the more you make, the easier it will be to start using your Zapier integration. Open the [Zap Template Creator](https://zapier.com/developer/zap-templates/create) again and create any more Zap Templates you want.
+#### Published Templates
+
+If your templates adhere to our style and construction guidelines, they will be marked Public. They will then automatically show up on your app's Zapier App Directory page. Most importantly, **[Public Zap Templates can be embedded into your app and across your website](https://zapier.com/partner/embed/)**, allowing you seamlessly extend your product and integration support by incorporating automated workflows where your users are looking for them. This is the best way to to promote adoption of your Zapier integration, increasing the value and retention of your user-base overall. 
+
+[Learn more about embedding tools like our JavaScript Widgets and Partner API here.](https://platform.zapier.com/partner_api/embedding)
+
+Then go ahead and make some more Zap Templates! Every Zapier integration must have at least 10 Zap Templates, and the more you make, the easier it will be to start using your Zapier integration. Open the [Zap Template Creator](https://zapier.com/developer/zap-templates/create) again and create any more Zap Templates you want.
+
+<a id="rejected-zap-templates"></a>
+#### Rejected Zap Templates
+
+If your templates do not comply with an aspect of our guidelines, whether from your title/description or how your template is built, they will be rejected back to you. 
+
+**Request for updates:** Most of the time, templates only need a few updates to align with our guidelines. Every 24 hours, our system digests all Zap Templates created by an author and emails them with a roundup. 
+
+The reason for each Zap Template's rejection is included in this email, and visible in the sharing menu for your template.
+
+The most typical issues are titles and descriptions that are simply copies with different app names, and missing mapping in the action step. Please refer to the list below for more detail on common rejections:
+
+- _Needs a unique title/description:_ Your template was submitted with non-unique titles. Please reference [title](https://platform.zapier.com/partners/zap-templates#how-to-write-a-zap-template-title) and [description](https://platform.zapier.com/partners/zap-templates#how-to-write-a-zap-template-description) style guidelines and resubmit.
+- _Has content or style guide issues:_ There are other specific issues with your template - please review additional provided detail and general guidelines.
+- _Usecase is too specific:_ Templates are meant to be broad, starter usecases. Most commonly they have two steps, possibly three if a partner's integration value comes primarily from search actions. Templates with too many steps become too specific to be useful - we recommend building tutorials and referencing Shared Zaps for these.
+- _Mappings are incorrect or incomplete:_ Fields that were available from your trigger or preceding actions were not mapped, or not mapped accurately. Refer to [Action step guidelines.](https://platform.zapier.com/partners/zap-templates#2-add-an-action-step)
+- _Template already exists:_ Template duplicates another public template, or you submitted duplicates. Please consult the [Zapier App Directory](https://zapier.com/apps) to explore our public templates.
+- _Content should be in English:_ We only support Zap Templates in English.
+- _Includes unallowed apps:_ We do not support Zap Templates with Code steps, or Webhooks with hardcoded destinations/origins as replacements for integrations.
+- _Other:_ Zap Template reviewers may reject your template for different or additional reasons, provided below.
+
+**Invalid:** Unfortunately your Zap Template is not suitable for public status - often because it is too complex of a usecase.
+
+If you have questions about the invalidation or request for updates on any of your Zap Templates, please email us indicating the ID of your Zap Template (copy this from your Zap Template menu)
 
 ## Promote Your Zap Templates
 
@@ -228,7 +261,7 @@ It’s not enough to turn your ideal workflows into Zap Templates. You need to g
 
 ![Zapier App Directory Page](https://cdn.zapier.com/storage/photos/b625939587cb8a8c7242f375c714d6aa.png)
 
-The easiest way to find Zap Templates is in Zapier’s [App Directory](https://zapier.com/apps/) where we have individual pages for each of the 1,300+ apps that integrate with Zapier. Want to find Gmail integrations? Go to [zapier.com/apps/gmail/integrations](https://zapier.com/apps/gmail/integrations/) to see the top apps connected with Gmail on Zapier, followed by a list of popular Gmail Zap Templates and Zapier content about Gmail use cases.
+The easiest way to find Zap Templates is in Zapier’s [App Directory](https://zapier.com/apps/) where we have individual pages for each of the thousands that integrate with Zapier. Want to find Gmail integrations? Go to [zapier.com/apps/gmail/integrations](https://zapier.com/apps/gmail/integrations/) to see the top apps connected with Gmail on Zapier, followed by a list of popular Gmail Zap Templates and Zapier content about Gmail use cases.
 
 Find your app’s App Directory page at `zapier.com/apps/YourApp/integrations`, replacing `YourApp` with your app’s name.
 

--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -21,7 +21,7 @@ They’re also a great way to promote your app, as your Zap Templates are featur
 
 Zap Templates can also be featured inside your site and content to help your users start using Zapier integrations. The more Zap Templates you create and the more users they have, the more likely they are to be featured. This helps your Zapier integration gain popularity and rise the ranks of the [Zapier Partner Program](https://zapier.com/platform/partner-program).
 
-You can create Zap Templates for any public Zapier integration, or for any integration that has applied for publishing. Once you apply for publishing your integration, you will need to build at least 10 Zap Templates in the [Zap Template Creator](https://zapier.com/developer/zap-templates/create) to help people start using your integration.
+You can create Zap Templates for any public Zapier integration, or for any integration that has applied for publishing. Once you apply for publishing your integration, you will need to [build at least 10 Zap Templates](https://zapier.com/developer/zap-templates/) to help people start using your integration.
 
 > Expected time to create a Zap Template: <10 minutes.
 
@@ -30,79 +30,81 @@ _An example Zap Template that automatically saves Gmail attachments to Google Dr
 
 ## How to Choose Zap Templates To Build
 
-You know your users best. Zap Templates should be built first and foremost to encourage people to adopt the usecases _you_ know are most valuable to your users. We recommend sourcing from your support teams, customer surveys, and internal usage of your product to determine all the various apps and workflows your users rely on every day - templatize and promote those!
+You know your users best. Zap Templates should be built first and foremost to encourage people to adopt the use cases _you_ know are most valuable to your users. We recommend sourcing from your support teams, customer surveys, and internal usage of your product to determine all the various apps and workflows your users rely on every day - templatize and promote those!
 
-These should be broad usecases with a starter user in mind - they are often simple, with 2 and rarely 3 steps. Zap Templates should also illustrate the widest possible range of pairings. Focus primarily on templatizing usecases with the apps you hear about the most, but we also recommend exploring our [App Directory](https://zapier.com/apps) by category and making templates for other apps in the same categories as your more popular pairings.
+These should be broad use cases with a starter user in mind - they are often simple, with 2 and rarely 3 steps. Zap Templates should also illustrate the widest possible range of pairings. Focus primarily on templatizing use cases with the apps you hear about the most, but we also recommend exploring our [App Directory](https://zapier.com/apps) by category and making templates for other apps in the same categories as your more popular pairings.
 
 Please review the entire style guide below before submitting templates for review, and take particular note of our [Rejected Zap Templates](https://platform.zapier.com/partners/zap-templates#rejected-zap-templates) section. Templates that do not comply with our style guide will be rejected - preparing in advance will save you time with rounds of iteration if changes are required.
 
 ## How to Build a Zap Template
 
-Zap Templates take a few steps to build, similar to any other Zap. You first select the app and trigger you want to start the Zap, then add an action app and map the fields from the trigger app to the action—and optionally add additional steps. Then, add a title and description to help people quickly understand when to use your Zap.
+Zap Templates take a few steps to build, similar to any other Zap. You first select the app and trigger you want to start the Zap, then add an action app and map the fields from the trigger app to the action, and optionally add additional steps. Then, add a title and description to help people quickly understand when to use your Zap.
 
 For help as you build, follow the instructions below:>
 
 ### 1. Add a Trigger Step
 
-![Zap Template select trigger app](https://cdn.zapier.com/storage/photos/800758ee8bf0437e6904dd7842760ac5.png)
+![Zap Template select trigger app](https://cdn.zappy.app/8aff0ad493d51826ccee104db6c0e5e4.png)
 
-Open Zapier’s [Zap Template creator](https://zapier.com/developer/zap-templates/create) at [zapier.com/developer/zap-templates/create](https://zapier.com/developer/zap-templates/create), or click the _Create Zap Template_ button in your [Zap Template dashboard](https://zapier.com/developer/zap-templates/). Select the trigger app, as you would when making a Zap for yourself. Select a popular app from the grid, or search for the app you need from the dropdown menu.
+Open Zapier’s [Zap editor](https://zapier.com/app/editor) at [zapier.com/app/editor](https://zapier.com/app/editor), or click the _Create Zap Template_ button in your [Zap Template dashboard](https://zapier.com/developer/zap-templates/). Select the trigger app, as you would when making a Zap for yourself. Select a popular app from the grid, or search for the app you need from the dropdown menu.
 
 > **Tip:** The ability to build and publish Zap Templates is only available if your Zapier integration has a [beta tag](https://platform.zapier.com/partners/lifecycle-planning/#beta) or has [officially launched](https://platform.zapier.com/partners/lifecycle-planning#4-launch-your-zapier-integration) and become a part of the Zapier Integration Partner Program.
 
-![Zap Template select trigger](https://cdn.zapier.com/storage/photos/ea3a3fb79b79782138180c0ce46e7ba5.png)
+![Zap Template select trigger](https://cdn.zappy.app/6dbf0a965d9aa555625007c722529d2e.png)
 
-Choose the app’s trigger that starts your Zap. Select one of the default options, search for the trigger you want, or click _show less common options_ if you can’t find the trigger you need.
+Choose the app’s trigger that starts your Zap. Select one of the default options, or search for the trigger you want.
 
-![Zap Template authentication](https://cdn.zapier.com/storage/photos/60167ed1a0c13415ebe471a591e7e62e.png)
+![Zap Template authentication](https://cdn.zappy.app/2611c54de844339901a29a684ff0f0f6.png)
 
-For most triggers from apps that require authentication, Zapier loads sample data similar to the data the app would send Zapier when it’s connected with a live account. Click the _Save + Continue_ button to use that in the next steps.
+For most triggers from apps that require authentication, Zapier loads sample data similar to the data the app would send Zapier when it’s connected with a live account. Click the _Use sample data for Zap template_ button to use that in the next steps.
 
-![Zap Template not including sample data](https://cdn.zapier.com/storage/photos/73a293c63f75e05cf68744faec6c5c97.png)
+![Zap Template not including sample data](https://cdn.zappy.app/ff5b689a7177c8ede85c27118b15b66b.png)
 
 Some triggers require authentication, but don't include sample data. If so, Zapier will note that in a message like the one above. You can still use that Zap in a Zap template, though when setting up the Zap's action step(s), you won't be able to pre-map fields for your users.
 
-![Zap Template built-in trigger](https://cdn.zapier.com/storage/photos/5a8fab320d5e48196d24e57e8173ce00.png)
+![Zap Template built-in trigger](https://cdn.zappy.app/8d366f9eee5beda1454c5755691062d1.png)
 
-If your trigger includes options—or if you're using a triggers such as Zapier’s _RSS_ or _Schedule_ tool that don’t require authentication—Zapier will then show additional settings for this trigger. Fill in any form fields, select multi-choice options, and click _Continue_ to save them. Or leave the defaults to let users add info to the Zap themselves—in which case, click the _Test This Step_ link in the left sidebar to skip the options.
+If your trigger includes options—or if you're using a triggers such as Zapier’s _RSS_ or _Schedule_ tool that don’t require authentication—Zapier will then show additional settings for this trigger. Fill in any form fields, select multi-choice options, and click _Continue_ to save them. Or leave the defaults to let users add info to the Zap themselves—in which case, skip forwards to the Action step.
+
+![Zap Template sample step](https://cdn.zappy.app/d72ac072095c82b17c9a9da883a0fe46.png)
 
 In the final trigger option, Zapier shows sample data from the app. You can click the down arrow on the sample data to see what details are included and the input fields you can use from this app in the rest of your workflow. Then again click _Continue_ to complete your Zap's trigger.
 
 ### 2. Add an Action Step
 
-![Zap Template add action app](https://cdn.zapier.com/storage/photos/f23d74b8ceb233c51cf0b2c138473cdd.png)
+![Zap Template add action app](https://cdn.zappy.app/a4ea7840171bcbbf64a3c455f9853373.png)
 
 Now add the action step to your Zap. Select the action app, either from the popular apps list or from the search menu.
 
 > **Tip:** You can use Zapier integrations that are publicly available or that have applied to be launched publicly.
 
-![Zap Template select action step](https://cdn.zapier.com/storage/photos/8dc73de8622e7fdde9e1da7286b96fd3.png)
+![Zap Template select action step](https://cdn.zappy.app/a8861fdf62d5dd1280bbf7d1314bc2a9.png)
 
-Choose the create or search action for your Zap, again using the search menu or _Show less common options_ tools if needed. You may then be prompted to use sample data as before; click _Continue_ to accept.
+Choose the create or search action for your Zap, or search for a specific action. You may then be prompted to use sample data as before; click _Continue_ to accept.
 
 > **Note**: If you use a search action, you need to also add a second action step to use the data from the trigger and search steps.
 
 As in the trigger step, when setting up most actions, you'll see a screen where your users will authenticate the action app—only in the Zap Template creator, Zapier uses this to pull in sample fields for the app.
 
-![Zap Template form fields](https://cdn.zapier.com/storage/photos/0871b7f9a9665d358465d81856f2432e.png)
+![Zap Template form fields](https://cdn.zappy.app/2818ab012b59523fe1f2e107705a4cb1.png)
 
 Now for the most crucial part of your Zap Template: Map the input fields from the trigger app to the form fields in this action app. The action step’s template shows every field that Zapier can send to the app, with required and optional fields. For the best Zap Templates, you want to fill in as many form fields as possible to help users set up Zaps quickly.
 
 > **Note**: Zap Templates' action fields _never_ show custom fields from apps, including spreadsheet columns, custom CRM fields, and other fields that are added by users, as Zapier's Template creator is not authenticated with an app account and custom fields will vary depending on the user. Your users will always need to add details to custom fields themselves.
 
-For most form fields, you need to add input fields from the trigger to the appropriate form field. Click the `+` button on the right of the field to see every input field from the trigger step. Select the input field that fits the action field best. For example, you might select Gmail’s _Attachment_ field to upload the attachment via Google Drive’s _File_ form field, or you might add Stripe’s _Email_ field to Mailchimp’s _Subscriber Email_ form field to add customers to an email list.
+For most form fields, you need to add input fields from the trigger to the appropriate form field. Click the gray _Enter text or insert data..._ to see every input field from the trigger step. Select the input field that fits the action field best. For example, you might select Gmail’s _Attachment_ field to upload the attachment via Google Drive’s _File_ form field, or you might add Stripe’s _Email_ field to Mailchimp’s _Subscriber Email_ form field to add customers to an email list.
 
 > **Tip**: Use [Zapier’s date and time syntax](https://zapier.com/help/modifying-dates-and-times/) to modify dates and times in action form fields.
 
 Most dropdown menus are used to select folders, projects, and other user-generated data and should be left blank by default. You can, however, select options for dropdowns for boolean yes/no fields if you're certain which option is best for this Zap Template.
 
-![Zap Template required fields](https://cdn.zapier.com/storage/photos/da280e25dbcb49ec47133874c0265e73.png)
+![Zap Template required fields](https://cdn.zappy.app/6c2bd1a34b961f0688a02c4d2e0b42f3.png)
 
-Zap Template action forms include _required for user_ and _optional for user_ fields. When users set up your Zap Template, they will see the required fields by default, and _must_ fill them in before turning on the Zap. Try to map as many required input fields as possible. Then, less-critical fields will often be marked as optional, and are hidden by default when users set up the Zap Template. If you know the best data to map to those fields, add them to make sure your users' Zaps include as much detail as possible.
+Zap Template action forms include _required for user_ and _optional for user_ fields. When users set up your Zap Template, they will see the required fields by default, and _must_ fill them in before turning on the Zap. Try to map as many required input fields as possible. Then, less-critical fields will often be marked as optional. If you know the best data to map to those fields, add them to make sure your users' Zaps include as much detail as possible.
 
 > **Note**: Do not enter plain text into an action form field unless _every_ user of this Zap Template would want the text included in the action.
 
-![Finish Zap Template Action](https://cdn.zapier.com/storage/photos/0bf7bddc4ac8cd16d90a4929f2baaaa3.png)
+![Finish Zap Template Action](https://cdn.zappy.app/b495ed24f8c5aa972a6e25ea0bf52011.png)
 
 Zapier then shows a test screen similar to what users see when setting up the Zap. Since you’re building a Zap Template, Zapier doesn’t create or add anything to your apps—the screen confirms everything should work correctly.
 
@@ -113,18 +115,18 @@ Now you have a choice: You can add another step to your Zap, or finish and save 
 Most Zap Templates only need two steps, with a Trigger to watch for data from an app and an Action to do something with that data. Sometimes, though, you need more steps for advanced workflows, including:
 
 - **Additional create actions** to add additional automations to your workflow
-- **[Filters](https://zapier.com/help/filter/)** to watch for specific items from trigger or action step(s)
-- **[Search actions](https://zapier.com/learn/getting-started-guide/search-actions/)** to find specific data from apps, recommended especially to find customers, tickets, projects, and more before creating new items with Zaps
+- **[Filters](https://zapier.com/help/create/customize/add-conditions-to-zaps-with-filters)** to watch for specific items from trigger or action step(s)
+- **[Search actions](https://zapier.com/help/create/basics/search-for-existing-data-in-zaps)** to find specific data from apps, recommended especially to find customers, tickets, projects, and more before creating new items with Zaps
 
 > **Note**: You cannot build Paths in Zap Templates at this time.
 
-To add another search or create action to your Zap, click the _Add a Step_ button after setting up your action above, then repeat step 2 and set up the additional action. To add a _delay_ action, select the _Delay by Zapier_ app when adding a new action.
+To add another search or create action to your Zap, click the `+` button after setting up your action above, then repeat step 2 and set up the additional action. To add a _delay_ action, select the _Delay by Zapier_ app when adding a new action.
 
-![Add Filter step to Zap Template](https://cdn.zapier.com/storage/photos/5a4b65b9cff4bd8bf951a171299794c6.png)
+![Add Filter step to Zap Template](https://cdn.zappy.app/8312f25171d144ccbec9628f6099e121.png)
 
-To add a filter, click the `+` button in the left sidebar and select _Filter_. You could add it between the trigger and action step to have the Zap only run when specific items come in from the trigger app, or you can add it after the action to watch for particular results (then add subsequent action steps to do more with data if it passes the filter criteria).
+To add a filter, click the `+` button after a Zap step, and then select _Filter_. You could add it between the trigger and action step to have the Zap only run when specific items come in from the trigger app, or you can add it after the action to watch for particular results (then add subsequent action steps to do more with data if it passes the filter criteria).
 
-![Customize Zapier Filter](https://cdn.zapier.com/storage/photos/e8e45015feffaae49d57a01a8e1162d6.png)
+![Customize Zapier Filter](https://cdn.zappy.app/411045bf12786168d1eebf824f29f260.png)
 
 Then add details to the filter, if this Zap should always watch for the same data. Select the field the filter should watch, then choose the filter criteria (if the text exists, doesn’t exist, if a number is greater than this value, etc.), and finally type in the text you need Zapier to find. If you need additional conditions in your filter, click the `+ AND` or `+ OR` buttons to add other criteria.
 
@@ -136,13 +138,23 @@ Alternately, leave the filter details blank and let users customize the filter t
 
 ### 4. Add a Title and Description
 
-![Zap Template Description](https://cdn.zapier.com/storage/photos/771335061cfa2e631707662981f7e7cb.png)
-
 Now for the final step: add Zap Template’s title and description, then submit your Zap Template for review.
 
-Zap Templates need to showcase a use case and describe it effectively. They provide inspiration for how to automate popular apps and workflows. Your Zap Template's description and title help sell that idea to users.
+![Zap Template Share](https://cdn.zappy.app/fd26334a8f0818e442e01e5bc46842c9.png)
 
-The title is the first thing people see. Embedded Zaps inside Zapier, your app, and blog posts and other content show the Zap's title and app icons. Titles need to fit in well in each environment and sell the use case at a glance.
+To finalize your Zap Template, click _Share_ in the upper right.
+
+![Zap Template Customize your shared Zap page](https://cdn.zappy.app/db06fc6542997ed5d140cb416ea5317c.png)
+
+And _Customize your shared Zap page_ in the modal.
+
+![Zap Template shared Zap page](https://cdn.zappy.app/84df95e80f4689c645da674f226e7ef1.png)
+
+This Zap page is where you can customize the title and description for your Zap Template.
+
+Zap Templates need to showcase a use case and describe it effectively. They provide inspiration for how to automate popular apps and workflows. Your Zap Template's title and description help sell that idea to users.
+
+Title is the first thing people see. Embedded Zaps inside Zapier, your app, and blog posts and other content show the Zap's title and app icons. Titles need to fit in well in each environment and sell the use case at a glance.
 
 Descriptions, then, are what users see when they click the Zap Template. They explain the use case and tell how the Zap works. The title grabs interest; the description gets people to invest the minute or three it takes to turn on the Zap.
 

--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -25,7 +25,7 @@ You can create Zap Templates for any public Zapier integration, or for any integ
 
 > Expected time to create a Zap Template: <10 minutes.
 
-![Example Zap Template](https://cdn.zappy.app/8b396feac45287ada0ca1025628f9082.gif)
+![Example Zap Template](https://github.com/zapier/visual-builder/blob/doyle-zap-templates-2021/Doyle-Zap-Template-2021-06-30.gif)
 _An example Zap Template that automatically sends saved Slack messages to Trello to create new cards._
 
 ## How to Choose Zap Templates To Build

--- a/docs/_partners/zap-templates.md
+++ b/docs/_partners/zap-templates.md
@@ -25,8 +25,8 @@ You can create Zap Templates for any public Zapier integration, or for any integ
 
 > Expected time to create a Zap Template: <10 minutes.
 
-![Example Zap Template](https://cdn.zapier.com/storage/photos/c89bedd08435ca8e9dc42b348eca732c.gif)
-_An example Zap Template that automatically saves Gmail attachments to Google Drive—a handy way to speed up email file management._
+![Example Zap Template](https://cdn.zappy.app/8b396feac45287ada0ca1025628f9082.gif)
+_An example Zap Template that automatically sends saved Slack messages to Trello to create new cards._
 
 ## How to Choose Zap Templates To Build
 
@@ -215,19 +215,17 @@ Keep these guidelines in mind:
 
 ---
 
-Once you've written and added your Zap Template title and description, it's time to save and test your work. Select `Draft` from the _Zap Template Visibility_ menu and click the _Save_ button.
-
 ![Test Zap Template](https://cdn.zapier.com/storage/photos/87a8cdc2f4d28b3ca8f743d0b332e84c.png)
 
 You should then try using the Zap Template to make sure it works as expected. Open your [Zap Template dashboard](https://zapier.com/developer/zap-templates/), click the gear icon beside the Zap Template you built, and select _Copy Link_. Open that link in a new tab or window, and follow the steps to set up and turn on the Zap—and make sure everything looks and works correctly.
-
-Optionally, you can let your team help test Zap Templates as well. When saving your Zap Template, choose `Shared` instead of draft, then share its link with others on your team so they can try the Zap Template.
 
 <a id="submit-your-zap-templates"></a>
 
 ### 5. Submit Zap Template for Review
 
-Finally, when your Zap Template is ready for public release, select the `For review` option on your Zap Template Visibility menu, and click _Save_ again. That submits the Zap Template to our team to review the Zap Template and ensure it works as expected and meets our standards.
+Finally, when your Zap Template is ready for public release, use the _Share_ button to open the publishing options modal, and the _Submit_ button. That submits the Zap Template to our team to review the Zap Template and ensure it works as expected and meets our standards.
+
+![Zap Template submit for review](https://cdn.zappy.app/acf31a3a067785c82770f3269851fa14.png)
 
 > **Note**: Zapier will only approve Zap Templates that include either public integrations or integrations that have applied for public release.
 
@@ -958,7 +956,7 @@ Here's what it would look like in the editor:
 
 If you'd like to provide a label for the value (e.g. a Board's name) you can do so by passing an additional parameter:
 
-`https://zapier.com/app/editor/template/2405?steps__1__params__board=12345&steps__1__meta__parammap__board=My+Board`
+`https://zapier.com/webintent/create-zap?template=2405&steps__1__params__board=12345&steps__1__meta__parammap__board=My+Board`
 
 ![](https://cdn.zapier.com/storage/photos/86b71a90bc69e5b13024c08f1da4b812.png)
 


### PR DESCRIPTION
# Do not merge yet

- #team-sharing-and-settings will merge when the full changes of the of the [ZS-758](https://zapierorg.atlassian.net/browse/ZS-758) ZT Creator Deprecation epic are ready to go live to end-users.

---

The current Zap Template Creator is being deprecated. In the future, partner developers will create Zap Templates in the regular Zap editor, and submit them for review through the sharing modal. This PR updates our partner-facing Zap Template docs to match the new behaviour.

- "4. Add a Title And Description" section changes most
- many screenshots updated // a new GIF file was uploaded to demo the 2021 experience of installing a Zap Template
- various URLs revised to new equivalents
- Ze added an extra section about Rejected Zap Templates

[ZS-758]: https://zapierorg.atlassian.net/browse/ZS-758